### PR TITLE
Fail the build when CERTIFICATEPASSWORD is empty.

### DIFF
--- a/DeployableApp/DeployableApp.csproj
+++ b/DeployableApp/DeployableApp.csproj
@@ -40,6 +40,10 @@
     <PropertyGroup>
       <SignTool>/p ""%25CERTIFICATEPASSWORD%25"" /a /f ..\..\..\Certificates\DeployableApp.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256</SignTool>
     </PropertyGroup>
+    <Exec Command="if &quot;%25CERTIFICATEPASSWORD%25&quot; equ &quot;&quot; exit 5" IgnoreExitCode="true" ConsoleToMSBuild="true">
+      <Output TaskParameter="ExitCode" PropertyName="_VCVarsAllFound" />
+    </Exec>
+    <Error Condition="'$(_VCVarsAllFound)' != '0'" Text="Cannot sign Installer files. Please set the CERTIFICATEPASSWORD environment variable to access the Certificate's private key." />
     <Exec Command="$(SquirrelToolsPath)\Squirrel.exe -n &quot;$(SignTool)&quot; --releasify $(PackageId).$(PackageVersion).nupkg"
           WorkingDirectory="$(PackageOutputAbsolutePath)"
     />


### PR DESCRIPTION
Do not use $(CERTIFICATEPASSWORD) MsBuild property to ensure that the password is not exposed in the build log.